### PR TITLE
スキーマの作成、エンドポイントの一部を作成

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -1,5 +1,6 @@
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
 
 """
 データベースの接続情報を設定

--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,8 @@
 from fastapi import FastAPI
-
+from src.routers import item
 
 app = FastAPI()
+app.include_router(item.router)
 
 
 @app.get("/")

--- a/src/models/item.py
+++ b/src/models/item.py
@@ -1,7 +1,13 @@
-from sqlalchemy import Column, Integer, String
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, String, DateTime
 from src.db import Base
+
+
 class Item(Base):
     __tablename__ = "items"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String, nullable=False)
     description = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.now, nullable=False)
+    updated_at = Column(DateTime, default=datetime.now, nullable=False)

--- a/src/routers/item.py
+++ b/src/routers/item.py
@@ -1,16 +1,32 @@
+from typing import List
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
 from sqlalchemy.orm import Session
-from src.schemas.item import Item
+from src.models.item import Item
+from src.schemas.item import Item as ItemCreate, ItemOrm
 
 from src.db import get_db
 
 router = APIRouter()
 
 
-@router.post("/items", response_model=Item)
-async def create_item(item_data: Item, db: Session = Depends(get_db)):
+@router.post("/items", response_model=ItemOrm)
+async def create_item(item_data: ItemCreate, db: Session = Depends(get_db)) -> ItemOrm:
     item = Item(**item_data.dict())
     db.add(item)
     db.commit()
     db.refresh(item)
+    return item
+
+@router.get("/items", response_model=List[ItemOrm])
+async def get_items(db: Session = Depends(get_db)) -> List[ItemOrm]:
+    items = db.scalars(select(Item)).all()
+    return items
+
+
+@router.get("/items/{item_id}", response_model=ItemOrm)
+async def get_item(item_id: int, db: Session = Depends(get_db)) -> ItemOrm:
+    item = db.scalars(select(Item).where(Item.id == item_id)).first()
+    if item is None:
+        raise HTTPException(status_code=404, detail="Item not found")
     return item

--- a/src/routers/item.py
+++ b/src/routers/item.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from src.schemas.item import Item
+
+from src.db import get_db
+
+router = APIRouter()
+
+
+@router.post("/items", response_model=Item)
+async def create_item(item_data: Item, db: Session = Depends(get_db)):
+    item = Item(**item_data.dict())
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item

--- a/src/schemas/item.py
+++ b/src/schemas/item.py
@@ -14,4 +14,4 @@ class ItemOrm(ItemBase):
     updated_at: datetime
 
     class Config:
-        orm_mode = True
+        from_attributes=True

--- a/src/schemas/item.py
+++ b/src/schemas/item.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+
+class ItemBase(BaseModel):
+    name: str = Field(None, example='キーボード')
+    description: str = Field(None, example='PCに入力する際に使用するガジェット。')
+
+class Item(ItemBase):
+    pass
+
+class ItemOrm(ItemBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## 実装の概要
以下実装した。
- Shemaの作成
- routerによるエンドポイントの作成（create_item, get_items, get_item）

## 実装理由・気づき
何かあれば。
- スキーマは`ItemBase`というベースとなる型を定義して、書込用のスキーマ(`Item`)と読取用のスキーマ(`ItemOrm`)を分けた。
- `Pydantic`のV2では、`orm_mode=True`の代わりに`from_attributes=True`を使用するらしい。

## 次回の実装内容
- 記事に必要なエンドポイントなどを作成する。